### PR TITLE
Fix player turn after loading save

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,6 +56,8 @@ function loadGame() {
     const obj = JSON.parse(data);
     if (obj.player) obj.player = new Player(obj.player);
     if (obj.enemy) obj.enemy = new Enemy(obj.enemy);
+    // Always start a new session on the player's turn to avoid being stuck
+    obj.isPlayerTurn = true;
     return obj;
 }
 


### PR DESCRIPTION
## Summary
- when loading saved state, always start on player's turn to avoid being stuck

## Testing
- `npm test` *(fails: no package.json)*