### PR TITLE
Fix player turn after loading save

### DIFF
--- a/game.js
+++ b/game.js
@@ -56,6 +56,8 @@ function loadGame() {
     const obj = JSON.parse(data);
     if (obj.player) obj.player = new Player(obj.player);
     if (obj.enemy) obj.enemy = new Enemy(obj.enemy);
+    // Always start a new session on the player's turn to avoid being stuck
+    obj.isPlayerTurn = true;
     return obj;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "rpg-true",
+  "version": "1.0.0",
+  "description": "Minimalist RPG prototype",
+  "scripts": {
+    "test": "node tests/loadGame.test.js"
+  },
+  "license": "MIT"
+}

--- a/tests/loadGame.test.js
+++ b/tests/loadGame.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync(__dirname + '/../game.js', 'utf8');
+const start = code.indexOf('function loadGame');
+const end = code.indexOf('/* --------- État du jeu --------- */', start);
+const loadGameCode = code.slice(start, end);
+
+const sandbox = {
+  localStorage: { getItem: () => null },
+  Player: function Player(data) { Object.assign(this, data); },
+  Enemy: function Enemy(data) { Object.assign(this, data); }
+};
+
+vm.createContext(sandbox);
+vm.runInContext(loadGameCode, sandbox);
+
+// Test returning null when no data
+let result = sandbox.loadGame();
+assert.strictEqual(result, null, 'loadGame should return null when there is no data');
+
+// Test resetting turn to player
+sandbox.localStorage.getItem = () => JSON.stringify({
+  player: null,
+  enemy: null,
+  isPlayerTurn: false
+});
+result = sandbox.loadGame();
+assert.strictEqual(result.isPlayerTurn, true, 'isPlayerTurn should be true after loading');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- when loading saved state, always start on player's turn to avoid being stuck
- add package.json with a simple test command
- add basic test verifying loadGame behavior

## Testing
- `npm test --silent`