### PR TITLE
Fix scenario step 2 freeze

### DIFF
--- a/game.js
+++ b/game.js
@@ -255,7 +255,13 @@ function chooseTalent(t) {
 
 function showScenario(step) {
     const sc = scenarios[step];
-    if (!sc) return;
+    // If there is no scenario for this step, simply continue the game by
+    // spawning a new enemy. This prevents the game from freezing when the
+    // scenario chain ends.
+    if (!sc) {
+        spawnNewEnemy();
+        return;
+    }
     scenarioText.textContent = sc.text;
     scenarioButtons.innerHTML = '';
     sc.choices.forEach(c => {


### PR DESCRIPTION
## Summary
- prevent lock when reaching undefined scenario steps by spawning a new enemy
- keep player's turn after enemy spawn and refresh bars

## Testing
- `npm test`