### PR TITLE
Ajout coût repos

### DIFF
--- a/game.js
+++ b/game.js
@@ -54,7 +54,7 @@ const scenarios = [
         choices: [
             { text: 'Passer à la forge', action: 'forge', next: 0 },
             { text: 'Visiter le magasin', action: 'shop', next: 0 },
-            { text: 'Se reposer', action: 'rest', next: 0 },
+            { text: 'Se reposer (10 or)', action: 'rest', next: 0 },
             { text: 'Continuer la route', action: 'road', next: 0 }
         ]
     }
@@ -386,9 +386,15 @@ function handleScenarioAction(action) {
         showShop();
         return;
     } else if (action === 'rest') {
-        const heal = Math.floor(gameState.player.maxHealth / 2);
-        gameState.player.health = Math.min(gameState.player.maxHealth, gameState.player.health + heal);
-        addBattleMessage(`Vous vous reposez et récupérez ${heal} PV.`, 'system');
+        const price = 10;
+        if (gameState.gold < price) {
+            addBattleMessage("Vous n'avez pas assez d'or pour vous reposer.", 'system');
+        } else {
+            gameState.gold -= price;
+            const heal = Math.floor(gameState.player.maxHealth / 2);
+            gameState.player.health = Math.min(gameState.player.maxHealth, gameState.player.health + heal);
+            addBattleMessage(`Vous payez ${price} or pour vous reposer et récupérez ${heal} PV.`, 'system');
+        }
         spawnNewEnemy();
     } else {
         spawnNewEnemy();

--- a/tests/restCost.test.js
+++ b/tests/restCost.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const code = fs.readFileSync(__dirname + '/../game.js', 'utf8');
+const start = code.indexOf('function handleScenarioAction');
+const end = code.indexOf('function showShop', start);
+const fnCode = code.slice(start, end);
+
+const sandbox = {
+  gameState: {
+    player: { maxHealth: 100, health: 50 },
+    gold: 20
+  },
+  addBattleMessage: () => {},
+  spawnNewEnemy: () => {},
+  updateHealthBars: () => {},
+  saveGame: () => {}
+};
+
+vm.createContext(sandbox);
+vm.runInContext(fnCode, sandbox);
+
+sandbox.handleScenarioAction('rest');
+assert.strictEqual(sandbox.gameState.gold, 10, 'gold should decrease when resting');
+assert.ok(sandbox.gameState.player.health > 50, 'health should be restored');
+
+console.log('Rest cost test passed.');

--- a/tests/runAllTests.js
+++ b/tests/runAllTests.js
@@ -3,3 +3,4 @@ require('./playerEnemy.test.js');
 require('./inventory.test.js');
 require('./statusEffects.test.js');
 require('./energyGold.test.js');
+require('./restCost.test.js');


### PR DESCRIPTION
## Notes
- Ajout d'un coût en or lors du repos après les combats.
- Nouveau test automatisé `restCost.test.js`.

## Summary
- l'option de repos indique désormais le prix dans `game.js`
- le repos retire 10 pièces d'or et soigne le joueur ou affiche un message si l'or est insuffisant
- ajout d'un test `restCost.test.js` et mise à jour de la suite de tests

## Testing
- `npm test`