### PR TITLE
Ajout d'une ambiance sonore basique

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ possibles :
 Le jeu utilise Tailwind et Font Awesome via des CDN ; une connexion Internet est
 nécessaire lors de l'exécution.
 
+### Ambiance sonore
+
+Une musique d'ambiance minimaliste est générée à l'aide de l'API Web Audio.
+Les bruitages principaux (attaques, soins...) sont également produits
+dynamiquement afin de renforcer l'atmosphère lors des combats.
+
 ### Développement
 
 Le code JavaScript se trouve maintenant dans `game.js` et les styles dans `style.css`.


### PR DESCRIPTION
## Notes
- Génération d'une musique d'ambiance et effets sonores via Web Audio API.
- La musique démarre lors du choix de la classe et s'arrête à la fin de la partie.

## Summary
- ajout d'un AudioContext et fonctions `startAmbientMusic`/`stopAmbientMusic`
- amélioration de `playSound` pour des fréquences différentes selon le type de message
- lancement de la musique lors de `selectClass` et arrêt dans `gameOver`
- documentation mise à jour sur l'ambiance sonore

## Testing
- `npm test --silent`