### PR TITLE
Ajout suivi de quêtes

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -147,6 +147,21 @@
             <div id="equipment-display" class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4"></div>
             <div id="inventory-items" class="grid grid-cols-2 sm:grid-cols-4 gap-4"></div>
         </div>
+
+        <!-- Quêtes -->
+        <div class="frosted-glass rounded-xl p-6 shadow-lg border border-blue-900/50 mt-6">
+            <h2 class="text-2xl font-bold text-blue-300 mb-4">Quêtes</h2>
+            <div id="quest-log" class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <h3 class="font-semibold mb-2">En cours</h3>
+                    <ul id="active-quests" class="space-y-1 text-sm"></ul>
+                </div>
+                <div>
+                    <h3 class="font-semibold mb-2">Terminées</h3>
+                    <ul id="completed-quests" class="space-y-1 text-sm text-gray-400"></ul>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Modales de choix -->


### PR DESCRIPTION
## Notes
- Ajout d'un journal des quêtes dans l'interface.
- Nouvelles quêtes "Herboriste" et "Premier équipement".
- Livraison de la lettre possible grâce à un scénario dédié.
- Les quêtes se mettent à jour automatiquement et rapportent de l'or lorsqu'elles sont terminées.

## Tests
- `npm test`