### PR TITLE
Ajout bonus de route et options audio

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -11,10 +11,14 @@
 <body class="bg-custom text-white min-h-screen flex flex-col items-center justify-center p-4 font-sans">
     <div class="max-w-4xl w-full">
         <!-- Header -->
-        <header class="text-center mb-8">
+        <header class="text-center mb-4">
             <h1 class="text-5xl font-bold mb-2 text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-blue-500">LUMINA</h1>
             <p class="text-xl text-blue-200">Un voyage à travers les ombres</p>
         </header>
+        <div class="flex justify-end space-x-4 mb-4 text-sm">
+            <label><input type="checkbox" id="music-toggle" checked class="mr-1">Musique</label>
+            <label><input type="checkbox" id="sfx-toggle" checked class="mr-1">Bruitages</label>
+        </div>
 
         <div id="location-container" class="frosted-glass rounded-xl mb-6 overflow-hidden">
             <img id="location-image" class="location-img" src="" alt="Lieu actuel">
@@ -211,7 +215,8 @@
 
     <div id="scenario-modal" class="fixed inset-0 bg-black/80 flex items-center justify-center hidden">
         <div class="bg-gray-800 p-6 rounded-xl space-y-4">
-            <p id="scenario-text" class="mb-4"></p>
+            <p id="scenario-text" class="mb-2"></p>
+            <p id="road-bonus-display" class="text-sm text-blue-200"></p>
             <div id="scenario-buttons" class="grid grid-cols-2 gap-2"></div>
         </div>
     </div>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ nécessaire lors de l'exécution.
 Une musique d'ambiance minimaliste est générée à l'aide de l'API Web Audio.
 Les bruitages principaux (attaques, soins...) sont également produits
 dynamiquement afin de renforcer l'atmosphère lors des combats.
+Des cases à cocher permettent désormais d'activer ou non la musique et les bruitages.
 
 ### Développement
 
@@ -50,6 +51,9 @@ Chaque ennemi vaincu rapporte désormais une petite somme d'or. Les gains de
 statistiques lors d'un passage de niveau sont indiqués dans le journal de
 combat. La génération d'énergie du voleur a également été augmentée pour rendre
 ses compétences plus faciles à utiliser.
+En choisissant plusieurs fois l'option « Continuer la route » dans les menus,
+un bonus d'attaque cumulatif apparaît. Il disparaît dès qu'une autre action est
+sélectionnée.
 
 ### Système de craft
 

--- a/player.js
+++ b/player.js
@@ -14,6 +14,7 @@ class Player {
         this.attackPenaltyTurns = this.attackPenaltyTurns || 0;
         this.tempCritBonus = this.tempCritBonus || 0;
         this.advancedEffect = this.advancedEffect || null;
+        this.roadBonus = this.roadBonus || 0;
     }
 
     startTurn() {
@@ -27,7 +28,7 @@ class Player {
         this.startTurn();
         let damage = Math.max(
             1,
-            this.attack - target.defense + Math.floor(Math.random() * 3)
+            this.attack + (this.roadBonus || 0) - target.defense + Math.floor(Math.random() * 3)
         );
         if (this.attackPenaltyTurns > 0) {
             damage = Math.floor(damage / 2);


### PR DESCRIPTION
## Notes
- Intégration d'un bonus cumulatif lorsque l'on choisit plusieurs fois « Continuer la route ». Le bonus est remis à zéro après toute autre action.
- Ajout des cases à cocher Musique et Bruitages pour activer ou non le son.
- La musique d'ambiance joue maintenant un petit motif répétitif.
- Les bruitages respectent le réglage on/off.
- Tests existants exécutés avec succès.
