### PR TITLE
Préparation des dépendances dès le lancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # RPG-true
 
 Ce projet contient un prototype de RPG textuel minimaliste en français.
+## Configuration initiale
+
+Avant que l'accès réseau ne soit désactivé dans Codex, exécutez `npm run setup` pour installer toutes les dépendances nécessaires (par exemple **jsdom** pour les tests). Ce script se trouve dans `scripts/setupDependencies.sh`.
+
 
 ## Utilisation
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "description": "Minimalist RPG prototype",
   "scripts": {
+    "setup": "sh scripts/setupDependencies.sh",
     "test": "node tests/runAllTests.js",
     "start": "node server.js"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "jsdom": "^23.1.0"
+  }
 }

--- a/scripts/setupDependencies.sh
+++ b/scripts/setupDependencies.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Installe les dépendances du projet avant la coupure réseau.
+# À utiliser dans Codex pour disposer de tous les modules nécessaires.
+
+npm install


### PR DESCRIPTION
## Notes
- Ajout du script `setupDependencies.sh` pour installer les paquets avant la coupure réseau.
- Mise à jour de `package.json` avec une commande `npm run setup` et l'ajout de **jsdom** dans les dépendances de développement.
- Documentation dans le README pour indiquer l'exécution de ce script.

## Summary
- Introduced a setup script to install dependencies prior to losing network connectivity.
- Added a `setup` npm script and declared `jsdom` as a dev dependency.
- Documented the new installation step in the README.
