### PR TITLE
Ajout finisher et ennemis élites

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -82,6 +82,9 @@
                     <button onclick="playerSpecial()" class="action-btn bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700" aria-label="Spécial">
                         <i class="fas fa-star mr-2" aria-hidden="true"></i> Spécial
                     </button>
+                    <button onclick="playerFinisher()" class="action-btn bg-gradient-to-r from-orange-500 to-red-600 hover:from-orange-600 hover:to-red-700" aria-label="Finisher">
+                        <i class="fas fa-skull-crossbones mr-2" aria-hidden="true"></i> Finisher
+                    </button>
                     <button onclick="playerFlee()" class="action-btn bg-gradient-to-r from-gray-500 to-gray-700 hover:from-gray-600 hover:to-gray-800" aria-label="Fuir">
                         <i class="fas fa-running mr-2" aria-hidden="true"></i> Fuir
                     </button>

--- a/player.js
+++ b/player.js
@@ -160,6 +160,24 @@ class Player {
         return damage;
     }
 
+    finisher(target) {
+        if (this.comboPoints < 5) return null;
+        this.startTurn();
+        this.comboPoints -= 5;
+        let damage = this.attack * 2;
+        if (this.class === 'mage') {
+            damage = Math.floor(this.attack * 2.2);
+        } else if (this.class === 'voleur') {
+            damage = Math.floor(this.attack * 1.8) + 5;
+        } else if (this.class === 'rodeur') {
+            damage = Math.floor(this.attack * 1.9);
+        } else {
+            damage = Math.floor(this.attack * 2);
+        }
+        target.takeDamage(damage, this.damageType);
+        return damage;
+    }
+
     tryFlee(enemy) {
         this.startTurn();
         const chance = 0.3 + (this.dodgeRate || 0);


### PR DESCRIPTION
## Notes
- implémente un finisher consommant 5 points de combo
- apparition aléatoire d'ennemis élites (5 %) avec bonus de stats et butin rare
- ajout d'une version de sauvegarde simplifiée
- arrêt/reprise de la musique lors du changement de visibilité

## Tests
- `npm test`